### PR TITLE
Fix configuration exports and supervisor config handling

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,59 +1,47 @@
-"""
-Package de configuration pour l'Agent IA de Cybersécurité
-
-Ce package contient toutes les configurations nécessaires pour le fonctionnement
-de l'application : paramètres généraux, prompts IA, base de vulnérabilités, etc.
-"""
+"""Package de configuration pour l'Agent IA de Cybersécurité."""
 
 from .settings import (
-    # Configuration générale
     Config,
     get_config,
-
-    # Paramètres de scan
+    validate_config,
+    get_nmap_config,
+    get_llm_config,
     NMAP_DEFAULT_ARGS,
     SCAN_TIMEOUT,
-
-    # Paramètres IA
     OPENAI_MODEL,
     MAX_TOKENS,
-
-    # Chemins
+    LOG_LEVEL,
+    LOG_FILE,
     DATABASE_PATH,
+    DATA_PATH,
     LOG_PATH,
-    DATA_PATH
+    VULNERABILITY_DB_PATH,
 )
 
 from .prompts import (
-    # Templates de prompts
     VULNERABILITY_ANALYSIS_PROMPT,
     SCRIPT_GENERATION_PROMPT,
-    PRIORITY_ASSESSMENT_PROMPT
+    PRIORITY_ASSESSMENT_PROMPT,
 )
 
-# Version du package de configuration
 __version__ = "1.0.0"
 
-# Export des éléments principaux
 __all__ = [
-    # Configuration
     "Config",
     "get_config",
-
-    # Constantes de scan
+    "validate_config",
+    "get_nmap_config",
+    "get_llm_config",
     "NMAP_DEFAULT_ARGS",
     "SCAN_TIMEOUT",
-
-    # Constantes IA
     "OPENAI_MODEL",
     "MAX_TOKENS",
-
-    # Chemins
+    "LOG_LEVEL",
+    "LOG_FILE",
     "DATABASE_PATH",
-    "LOG_PATH",
     "DATA_PATH",
-
-    # Prompts
+    "LOG_PATH",
+    "VULNERABILITY_DB_PATH",
     "VULNERABILITY_ANALYSIS_PROMPT",
     "SCRIPT_GENERATION_PROMPT",
     "PRIORITY_ASSESSMENT_PROMPT",

--- a/config/settings.py
+++ b/config/settings.py
@@ -69,6 +69,10 @@ class Config:
                 "wget", "curl", "git", "pip", "npm"
             ]
 
+    def get(self, key: str, default: Any = None) -> Any:
+        """Permet d'accéder aux attributs via une interface de type dictionnaire."""
+        return getattr(self, key, default)
+
 
 # === CONSTANTES GLOBALES ===
 

--- a/src/core/supervisor.py
+++ b/src/core/supervisor.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional, Callable, Union
 from dataclasses import dataclass, asdict
 
-from config import get_config, DEFAULT_CONFIG
+from config import get_config
 from src.utils.logger import setup_logger
 from src.database.database import Database
 from .collector import Collector, ScanResult
@@ -832,8 +832,8 @@ class Supervisor:
 
         Returns:
             WorkflowResult: Résultats complets
-            """
-            workflow_id = await self.start_workflow(
+        """
+        workflow_id = await self.start_workflow(
             WorkflowType.FULL_WORKFLOW,
             target,
             {"scan_type": scan_type}


### PR DESCRIPTION
## Summary
- re-export the configuration helpers and constants expected by the rest of the application
- add a dictionary-style `get` helper to the `Config` dataclass so core modules can use it transparently
- clean up the supervisor workflow helper to rely on the dataclass configuration and fix its docstring indentation

## Testing
- python -m compileall config src/core/supervisor.py

------
https://chatgpt.com/codex/tasks/task_e_68cacd95604c83309c271235348d97e5