### PR TITLE
Fix uvicorn entry point for API module

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -443,7 +443,7 @@ async def metrics():
 if __name__ == "__main__":
     # Configuration pour le développement
     uvicorn.run(
-        "main:app",
+        app,
         host="0.0.0.0",
         port=8000,
         reload=True,


### PR DESCRIPTION
## Summary
- start the development uvicorn server using the FastAPI app instance instead of the string import path

## Testing
- python src/api/main.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68cd495d49d88330bce42b0543e6f0e4