### PR TITLE
Refactor API dependencies into dedicated module

### DIFF
--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -1,0 +1,49 @@
+"""Dépendances partagées pour l'application FastAPI."""
+
+from typing import Dict, Any, Optional
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+from src.database.database import Database
+from src.core.supervisor import Supervisor
+
+security = HTTPBearer(auto_error=False)
+
+# Instances globales partagées
+supervisor_instance: Optional[Supervisor] = None
+database_instance: Optional[Database] = None
+
+
+def get_database() -> Database:
+    """Retourne l'instance initialisée de la base de données."""
+    if database_instance is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Base de données non initialisée",
+        )
+    return database_instance
+
+
+def get_supervisor() -> Supervisor:
+    """Retourne l'instance initialisée du superviseur."""
+    if supervisor_instance is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Superviseur non initialisé",
+        )
+    return supervisor_instance
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> Dict[str, Any]:
+    """Dépendance pour l'authentification (actuellement permissive)."""
+    if credentials is None:
+        return {"user_id": "anonymous", "role": "user"}
+
+    token = credentials.credentials
+    if not token:
+        raise HTTPException(status_code=401, detail="Token manquant")
+
+    return {"user_id": "authenticated", "role": "user"}

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -16,7 +16,7 @@ import json
 from src.database.database import Database
 from src.core.supervisor import Supervisor
 from src.utils.logger import setup_logger
-from .main import get_database, get_supervisor, get_current_user
+from .dependencies import get_database, get_supervisor, get_current_user
 from .schemas import (
     ScanRequest,
     ScanResponse,


### PR DESCRIPTION
## Summary
- extract the FastAPI dependency helpers into `src/api/dependencies.py` so they can be shared between the application and routers
- update the API bootstrap to manage shared database and supervisor instances through the new dependency module before including the router
- add minimal validator helpers and sanitisation fixes so ancillary imports used during application startup resolve cleanly

## Testing
- python -m compileall src/api
- uvicorn src.api.main:app --host 127.0.0.1 --port 8000 --log-level warning *(fails: ImportError: cannot import name 'NmapXMLParser' from 'src.utils.parsers')*

------
https://chatgpt.com/codex/tasks/task_e_68cd4959372483309d6d9e3c9f99c0d0