### PR TITLE
Restore CLI exports with lazy loading

### DIFF
--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -991,9 +991,9 @@ def sanitize_command_input(command: str) -> str:
         return ""
 
     # Supprimer les caractères dangereux pour le shell
-    dangerous_chars = [';', '&', '|', '`', ', '(', ')', '{', '}', '[', ']', ' < ', ' > ']
+    dangerous_chars = [';', '&', '|', '`', '(', ')', '{', '}', '[', ']', '<', '>']
 
-                       cleaned = command
+    cleaned = command
     for char in dangerous_chars:
         cleaned = cleaned.replace(char, '')
 


### PR DESCRIPTION
## Summary
- restore the `src` package exports with lazy attribute loading and include the missing banner/status helpers
- make the CLI entrypoint lazily import optional dependencies and skip prerequisite checks when only asking for help
- fix `sanitize_command_input` so the validators module imports without syntax errors

## Testing
- python main.py --help

------
https://chatgpt.com/codex/tasks/task_e_68cd495842bc83308e7029a15d455cd7